### PR TITLE
fix: connection and oob invitation representations

### DIFF
--- a/acapy_revocation_demo/controller/invitation.py
+++ b/acapy_revocation_demo/controller/invitation.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type
 from acapy_client.models.conn_record import ConnRecord
 from acapy_client.models.invitation_message import InvitationMessage
 from acapy_client.models.connection_invitation import (
@@ -9,11 +9,16 @@ from acapy_client.models.connection_invitation import (
 
 from acapy_client.models.invitation_record import InvitationRecord
 from acapy_client.models.invitation_result import InvitationResult
+from dataclasses import dataclass, asdict
 
 from acapy_revocation_demo.controller.utils import unwrap
 
 from .record import Record
 from .connection import Connection
+from .api import Api
+from acapy_client.api.did_exchange import (
+    post_didexchange_conn_id_accept_invitation as _accept_oob_invitation,
+)
 
 if TYPE_CHECKING:
     from .controller import Controller
@@ -111,3 +116,88 @@ class OOBInvitation(Record[InvitationRecord]):
             event.payload["connection_id"],
             ConnRecord.from_dict(event.payload),
         )
+
+    async def oob_from_event(self) -> "OOB":
+        """Get connection from invitation record through event."""
+        assert self.controller.event_queue
+        LOGGER.info(
+            "%s: %s awaiting associated out_of_band event...",
+            self.name,
+            type(self).__name__,
+        )
+        event = await self.controller.event_queue.get(
+            lambda event: event.topic == OOB.topic
+            and event.payload["invi_msg_id"] == self.invitation_id,
+            timeout=3,
+        )
+        LOGGER.info("%s: %s oob found", self.name, type(self).__name__)
+        LOGGER.debug(
+            "%s oob record: %s",
+            type(self).__name__,
+            json.dumps(event.payload, sort_keys=True),
+        )
+        return OOB(
+            self.controller,
+            event.payload["oob_id"],
+            event.payload["connection_id"],
+            OOBRecord.from_dict(event.payload),
+        )
+
+
+# TODO No model for OOBRecord in ACA-Py Client...
+@dataclass
+class OOBRecord:
+    oob_id: str
+    state: str
+    invi_msg_id: str
+    invitation: dict
+    connection_id: str
+    role: str
+    created_at: str
+    updated_at: str
+    trace: bool
+    their_service: Optional[dict] = None
+    attach_thread_id: Optional[str] = None
+    our_recipient_key: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls: Type["OOBRecord"], src_dict: dict) -> "OOBRecord":
+        return cls(**src_dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class OOB(Record[OOBRecord]):
+    topic = "out_of_band"
+
+    def __init__(
+        self,
+        controller: "Controller",
+        oob_id: str,
+        connection_id: str,
+        record: OOBRecord,
+    ):
+        super().__init__(controller, record)
+        self.oob_id = oob_id
+        self.connection_id = connection_id
+
+    async def done(self):
+        await self.wait_for_state("done")
+        self.connection_id = unwrap(self.record.connection_id)
+
+    async def reuse_accepted(self):
+        await self.wait_for_state("reuse-accepted")
+
+    async def accept_invitation(self) -> Connection:
+
+        accept_oob_invitation = Api(
+            self.name,
+            _accept_oob_invitation._get_kwargs,
+            _accept_oob_invitation.asyncio_detailed,
+        )
+
+        result = await accept_oob_invitation(
+            client=self.client, conn_id=self.connection_id
+        )
+        return Connection(self.controller, self.connection_id, result)

--- a/acapy_revocation_demo/controller/record.py
+++ b/acapy_revocation_demo/controller/record.py
@@ -3,8 +3,10 @@ from abc import abstractproperty
 import json
 import logging
 from typing import (
+    Any,
     Callable,
     ClassVar,
+    Dict,
     Generic,
     Optional,
     Protocol,
@@ -14,6 +16,7 @@ from typing import (
 )
 
 from acapy_client.client import Client
+from .utils import unwrap
 
 if TYPE_CHECKING:
     from .controller import Controller, Event
@@ -27,6 +30,13 @@ T = TypeVar("T")
 class RecordProtocol(Protocol):
     @classmethod
     def from_dict(cls: Type[T], src_dict: dict) -> T:
+        ...
+
+    def to_dict(self) -> Dict[str, Any]:
+        ...
+
+    @property
+    def state(self) -> str:
         ...
 
 
@@ -45,6 +55,17 @@ class Record(Generic[RecordType]):
     @property
     def client(self) -> Client:
         return self.controller.client
+
+    @property
+    def state(self) -> str:
+        return unwrap(self.record.state)
+
+    def __repr__(self):
+        return (
+            f"<{type(self).__name__} "
+            f"name={self.name}, "
+            f"record={self.record.to_dict()}>"
+        )
 
     @abstractproperty
     def name(self) -> str:


### PR DESCRIPTION
This PR corrects some issues with invitations that we ran into while working with connection reuse.

@mepeltier these are the changes we made from the `test/conn-reuse` branch just yanked into a new branch and excluding the changes to `__main__.py`.