### PR TITLE
feat: add simple test setup

### DIFF
--- a/acapy_revocation_demo/__main__.py
+++ b/acapy_revocation_demo/__main__.py
@@ -246,6 +246,8 @@ async def main(
         for pres in presentations:
             print(pres.summary())
 
+    return presentations
+
 
 if __name__ == "__main__":
     asyncio.get_event_loop().run_until_complete(main())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   holder:
-    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.3
+    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.4
     ports:
       - 3000:3000
       - 3001:3001
@@ -26,12 +26,18 @@ services:
         --auto-provision
         --notify-revocation
         --monitor-revocation-notification
+    healthcheck:
+      test: curl -s -o /dev/null -w '%{http_code}' "http://localhost:3001/status/live" | grep "200" > /dev/null
+      start_period: 10s
+      interval: 5s
+      timeout: 10s
+      retries: 10
     depends_on:
       - tails
       - webhook-listener
 
   issuer:
-    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.3
+    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.4
     ports:
       - 3002:3000
       - 3003:3001
@@ -57,12 +63,18 @@ services:
         --auto-provision
         --notify-revocation
         --monitor-revocation-notification
+    healthcheck:
+      test: curl -s -o /dev/null -w '%{http_code}' "http://localhost:3001/status/live" | grep "200" > /dev/null
+      start_period: 10s
+      interval: 5s
+      timeout: 10s
+      retries: 10
     depends_on:
       - tails
       - webhook-listener
 
   verifier:
-    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.3
+    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.4
     ports:
       - 3004:3000
       - 3005:3001
@@ -88,6 +100,12 @@ services:
         --auto-provision
         --notify-revocation
         --monitor-revocation-notification
+    healthcheck:
+      test: curl -s -o /dev/null -w '%{http_code}' "http://localhost:3001/status/live" | grep "200" > /dev/null
+      start_period: 10s
+      interval: 5s
+      timeout: 10s
+      retries: 10
     depends_on:
       - tails
       - webhook-listener
@@ -115,14 +133,30 @@ services:
       context: .
       dockerfile: ./docker/Dockerfile.demo
     environment:
-      - WAIT_BEFORE_HOSTS=3
-      - WAIT_HOSTS=holder:3000,issuer:3000
-      - WAIT_HOSTS_TIMEOUT=30
-      - WAIT_SLEEP_INTERVAL=1
-      - WAIT_HOST_CONNECT_TIMEOUT=10
-      - HOLDER=http://holder:3001
-      - ISSUER=http://issuer:3001
-      - VERIFIER=http://issuer:3001
+      HOLDER: "http://holder:3001"
+      ISSUER: "http://issuer:3001"
+      VERIFIER: "http://issuer:3001"
     depends_on:
-      - holder
-      - issuer
+      holder:
+        condition: service_healthy
+      issuer:
+        condition: service_healthy
+      verifier:
+        condition: service_healthy
+
+  tests:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile.demo
+    environment:
+      HOLDER: "http://holder:3001"
+      ISSUER: "http://issuer:3001"
+      VERIFIER: "http://issuer:3001"
+    entrypoint: poetry run pytest
+    depends_on:
+      holder:
+        condition: service_healthy
+      issuer:
+        condition: service_healthy
+      verifier:
+        condition: service_healthy

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -3,11 +3,6 @@ FROM python:3.10
 WORKDIR /usr/src/app
 RUN pip install poetry
 
-# Add docker-compose-wait tool -------------------
-ENV WAIT_VERSION 2.7.2
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/$WAIT_VERSION/wait /wait
-RUN chmod +x /wait
-
 RUN mkdir acapy_revocation_demo && touch acapy_revocation_demo/__init__.py
 COPY ./pyproject.toml .
 COPY ./poetry.lock .
@@ -15,5 +10,6 @@ COPY ./README.md .
 
 RUN poetry install
 COPY ./acapy_revocation_demo acapy_revocation_demo
+COPY ./tests tests
 
-ENTRYPOINT ["/bin/sh", "-c", "/wait && poetry run python -m acapy_revocation_demo \"$@\"", "--"]
+CMD ["poetry", "run", "python", "-m", "acapy_revocation_demo"]

--- a/docker/Dockerfile.openapi-generator
+++ b/docker/Dockerfile.openapi-generator
@@ -1,7 +1,0 @@
-FROM python:3.6
-
-WORKDIR /usr/src/app
-
-RUN pip install openapi-python-client
-
-ENTRYPOINT ["/bin/sh", "-c", "openapi-python-client \"$@\"", "--"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -82,6 +82,14 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "atomicwrites"
+version = "1.4.1"
+description = "Atomic file writes."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "attrs"
 version = "22.1.0"
 description = "Classes Without Boilerplate"
@@ -172,7 +180,7 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 name = "colorama"
 version = "0.4.5"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -288,7 +296,7 @@ python-versions = ">=3.5"
 name = "importlib-metadata"
 version = "4.12.0"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -300,6 +308,14 @@ zipp = ">=0.5"
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "mccabe"
@@ -334,6 +350,17 @@ optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
 
 [[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
 name = "pathspec"
 version = "0.9.0"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -354,6 +381,21 @@ docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehint
 test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
 
 [[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "pre-commit"
 version = "2.20.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
@@ -371,6 +413,14 @@ toml = "*"
 virtualenv = ">=20.0.8"
 
 [[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "pycodestyle"
 version = "2.7.0"
 description = "Python style guide checker"
@@ -385,6 +435,54 @@ description = "passive checker of Python programs"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyparsing"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+category = "main"
+optional = false
+python-versions = ">=3.6.8"
+
+[package.extras]
+diagrams = ["railroad-diagrams", "jinja2"]
+
+[[package]]
+name = "pytest"
+version = "7.1.2"
+description = "pytest: simple powerful testing with Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+py = ">=1.8.2"
+tomli = ">=1.0.0"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.19.0"
+description = "Pytest support for asyncio"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pytest = ">=6.1.0"
+typing-extensions = {version = ">=3.7.2", markers = "python_version < \"3.8\""}
+
+[package.extras]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)", "flaky (>=3.5.0)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
 name = "python-dateutil"
@@ -447,7 +545,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -502,7 +600,7 @@ typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 name = "zipp"
 version = "3.8.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -513,7 +611,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "4caec1f7b92f985d51b56fbf23a5bb72e69861816660cd6f53b799b996ef6679"
+content-hash = "1eaea433fc9768757d5f5ee1549113e29e1a65f1a17e0b6cf4b9577951bbfb06"
 
 [metadata.files]
 acapy-client = []
@@ -522,6 +620,7 @@ aiosignal = []
 anyio = []
 async-timeout = []
 asynctest = []
+atomicwrites = []
 attrs = []
 black = []
 blessings = []
@@ -540,15 +639,22 @@ httpx = []
 identify = []
 idna = []
 importlib-metadata = []
+iniconfig = []
 mccabe = []
 multidict = []
 mypy-extensions = []
 nodeenv = []
+packaging = []
 pathspec = []
 platformdirs = []
+pluggy = []
 pre-commit = []
+py = []
 pycodestyle = []
 pyflakes = []
+pyparsing = []
+pytest = []
+pytest-asyncio = []
 python-dateutil = []
 pyyaml = []
 rfc3986 = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ python = "^3.7"
 acapy-client = "0.7.4"
 aiohttp = "^3.8.1"
 blessings = "^1.7"
+pytest = "^7.1.2"
+pytest-asyncio = "^0.19.0"
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+from os import getenv
+
+import pytest
+from acapy_revocation_demo import Controller
+
+TIMEOUT = int(getenv("TIMEOUT", "30"))
+
+
+def getenv_or_raise(var: str) -> str:
+    value = getenv(var)
+    if value is None:
+        raise ValueError(f"Missing environmnet variable: {var}")
+
+    return value
+
+
+@pytest.fixture
+def issuer():
+    yield Controller("issuer", getenv_or_raise("ISSUER"), long_timeout=TIMEOUT)
+
+
+@pytest.fixture
+def verifier():
+    yield Controller("issuer", getenv_or_raise("ISSUER"))
+
+
+@pytest.fixture
+def holder():
+    yield Controller("issuer", getenv_or_raise("ISSUER"))

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,20 @@
+"""Run tests with the agents."""
+from typing import cast
+import pytest
+
+from acapy_revocation_demo import Controller
+from acapy_revocation_demo.__main__ import main
+from acapy_revocation_demo.controller.utils import unwrap
+
+
+@pytest.mark.asyncio
+async def test_main(issuer: Controller, verifier: Controller, holder: Controller):
+    """Test the main script."""
+    presentations = await main(issuer, verifier, holder)
+    for pres in presentations:
+        comment = cast(str, unwrap(pres.record.presentation_request_dict).comment)
+        if "should verify false" in comment:
+            assert str(pres.record.verified) == "false"
+
+        if "should verify true" in comment:
+            assert str(pres.record.verified) == "true"


### PR DESCRIPTION
This PR adds a simple test setup. This serves multiple purposes:

- If we're creating a demo, we can format it as a test suite.
- Written tests on demo or fix branches can act as a regression test suite.
- This will help validate changes in dependencies (i.e. acapy updates, client updates, etc.)